### PR TITLE
Update zigbee-sonoff-motion-sensor-expanded.groovy

### DIFF
--- a/drivers/expanded/zigbee-sonoff-motion-sensor-expanded.groovy
+++ b/drivers/expanded/zigbee-sonoff-motion-sensor-expanded.groovy
@@ -1292,7 +1292,7 @@ void zigbee_sonoff_parseBatteryData(Map msgMap) {
         }
     }
     if(bat != null) {
-        bat = bat.setScale(1, BigDecimal.ROUND_HALF_UP)
+        bat = bat.setScale(0, BigDecimal.ROUND_HALF_UP)
         sendEvent(name:"battery", value: bat , unit: "%", isStateChange: false)
     }
 }


### PR DESCRIPTION
Hi guys. Thanks a lot for your work. I want to suggest you a change of the format of battery attribute to an integer. Hubitat Dashboard with Smartly can not render a Battery tile properly when the value is in decimal format. The same may be relevant for other drivers then this one. Thanks. Michal